### PR TITLE
feat: add project generation with JS/TS choice via create-next-app

### DIFF
--- a/bin/nexter-cli.mjs
+++ b/bin/nexter-cli.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-console.log(`
-✨ Welcome to create-nexter CLI!
-Your Next.js + Tailwind starter tool.
-`);
+import main from '../src/index.js';
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,107 @@
+{
+  "name": "create-nexter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "create-nexter",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "nexter": "bin/nexter-cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "dependencies": {
+    "cross-spawn": "^7.0.6",
+    "prompts": "^2.4.2"
   }
 }

--- a/src/generators/projectGenerator.js
+++ b/src/generators/projectGenerator.js
@@ -1,0 +1,17 @@
+import spawn from 'cross-spawn';
+
+export default function generateProject(language, projectName) {
+  return new Promise((resolve, reject) => {
+    const args = ['create-next-app@latest', projectName];
+    if (language === 'ts') args.push('--typescript');
+
+    const cmd = 'npx';
+
+    const child = spawn(cmd, args, { stdio: 'inherit' });
+
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`create-next-app exited with code ${code}`));
+    });
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,26 @@
+import prompts from 'prompts';
+import languagePrompt from './prompts/languagePrompt.js';
+import generateProject from './generators/projectGenerator.js';
+
+export default async function main() {
+  console.log('✨ Welcome to create-nexter CLI!');
+
+  const { language } = await languagePrompt();
+
+  const { projectName } = await prompts({
+    type: 'text',
+    name: 'projectName',
+    message: 'Enter your project folder name',
+    initial: 'my-nexter-app',
+    validate: name => (name.trim() === '' ? 'Project name cannot be empty' : true)
+  });
+
+  console.log(`Generating Next.js project '${projectName}' with language: ${language}`);
+
+  try {
+    await generateProject(language, projectName);
+    console.log('🎉 Project created successfully!');
+  } catch (err) {
+    console.error('❌ Error during project generation:', err);
+  }
+}

--- a/src/prompts/languagePrompt.js
+++ b/src/prompts/languagePrompt.js
@@ -1,0 +1,13 @@
+import prompts from 'prompts';
+
+export default async function languagePrompt() {
+  return prompts({
+    type: 'select',
+    name: 'language',
+    message: 'Choose your language',
+    choices: [
+      { title: 'JavaScript', value: 'js' },
+      { title: 'TypeScript', value: 'ts' }
+    ]
+  });
+}


### PR DESCRIPTION
This PR implements the initial project generation feature for the create-nexter CLI.

- Adds interactive prompts to select JavaScript or TypeScript.
- Asks for the project folder name.
- Uses `npx create-next-app` under the hood to generate a Next.js project with the selected language.
- Ensures a clean and professional CLI experience with real-time output.

This sets the foundation for future enhancements such as project structure customization and additional tooling integrations.

Closes #1
